### PR TITLE
Human-readable naming for tf frames

### DIFF
--- a/include/azure_kinect_ros_driver/k4a_ros_device.h
+++ b/include/azure_kinect_ros_driver/k4a_ros_device.h
@@ -112,6 +112,43 @@ class K4AROSDevice
   // When using IMU throttling, computes a mean measurement from a set of IMU samples
   k4a_imu_sample_t computeMeanIMUSample(const std::vector<k4a_imu_sample_t>& samples);
 
+  // TF joint naming
+  // Reference: https://docs.microsoft.com/en-us/azure/kinect-dk/body-joints
+  const std::string jointNames[32] = {
+    "pelvis",
+    "spine_naval",
+    "spine_chest",
+    "neck",
+    "clavicle_left",
+    "shoulder_left",
+    "elbow_left",
+    "wrist_left",
+    "hand_left",
+    "handtip_left",
+    "thumb_left",
+    "clavicle_right",
+    "shoulder_right",
+    "elbow_right",
+    "wrist_right",
+    "hand_right",
+    "handtip_right",
+    "thumb_right",
+    "hip_left",
+    "knee_left",
+    "ankle_left",
+    "foot_left",
+    "hip_right",
+    "knee_right",
+    "ankle_right",
+    "foot_right",
+    "head",
+    "nose",
+    "eye_left",
+    "ear_left",
+    "eye_right",
+    "ear_right"
+  };
+
   // ROS Node variables
   ros::NodeHandle node_;
   ros::NodeHandle private_node_;

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -749,7 +749,7 @@ k4a_result_t K4AROSDevice::getBodyMarker(const k4abt_body_t& body, MarkerPtr mar
   transform.setRotation(q);
 
   std::ostringstream ss;
-  ss << body.id << "_" << jointType;
+  ss << body.id << "_" << jointNames[jointType];
   tf_broadcaster_->sendTransform(tf::StampedTransform(transform, ros::Time::now(), calibration_data_.tf_prefix_ + calibration_data_.depth_camera_frame_, ss.str()));
 
 

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -741,8 +741,6 @@ k4a_result_t K4AROSDevice::getBodyMarker(const k4abt_body_t& body, MarkerPtr mar
   marker_msg->pose.orientation.y = orientation.wxyz.y;
   marker_msg->pose.orientation.z = orientation.wxyz.z;
 
-  std::cout << "joint type" << jointType << std::endl;
-
   tf::Transform transform;
   transform.setOrigin( tf::Vector3(marker_msg->pose.position.x, marker_msg->pose.position.y, marker_msg->pose.position.z) );
   tf::Quaternion q( marker_msg->pose.orientation.x, marker_msg->pose.orientation.y, marker_msg->pose.orientation.z, marker_msg->pose.orientation.w);


### PR DESCRIPTION
### Description of the changes:
- Adds a list of human-readable joint names to `K4AROSDevice`, order chosen according to https://docs.microsoft.com/en-us/azure/kinect-dk/body-joints
- Publishes tf frames now as, e.g., $id_nose instead of $id_27

### Required before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [x] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

### I tested changes on: 
- [ ] Windows
- [x] Linux
- [x] ROS1
- [ ] ROS2

