### PR TITLE
Project 3d positions onto 2D image plane via RGB intrinsics

### DIFF
--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -812,7 +812,7 @@ k4a_result_t K4AROSDevice::renderBodyIndexMapToROS(sensor_msgs::ImagePtr body_in
   return K4A_RESULT_SUCCEEDED;
 }
 
-k4a_result_t setPixelFromMarker(kobo_interaction_msgs::PixelSkeleton &pixel_skeleton, const visualization_msgs::MarkerPtr marker_msg, int jointType)
+k4a_result_t K4AROSDevice::setPixelFromMarker(kobo_interaction_msgs::PixelSkeleton &pixel_skeleton, const visualization_msgs::MarkerPtr marker_msg, int jointType)
 {
   // Project with intrinsics
   kobo_interaction_msgs::Pixel pixel;

--- a/src/k4a_ros_device.cpp
+++ b/src/k4a_ros_device.cpp
@@ -814,9 +814,11 @@ k4a_result_t K4AROSDevice::renderBodyIndexMapToROS(sensor_msgs::ImagePtr body_in
 
 k4a_result_t setPixelFromMarker(kobo_interaction_msgs::PixelSkeleton &pixel_skeleton, const visualization_msgs::MarkerPtr marker_msg, int jointType)
 {
+  // Project with intrinsics
   kobo_interaction_msgs::Pixel pixel;
-  pixel.x = marker_msg->pose.position.x;
-  pixel.y = marker_msg->pose.position.y;
+  k4a_calibration_intrinsic_parameters_t* parameters = &calibration_data_.k4a_calibration_.color_camera_calibration.intrinsics.parameters;
+  pixel.x = (parameters->param.fx * marker_msg->pose.position.x + parameters->param.cx * marker_msg->pose.position.z) / marker_msg->pose.position.z;
+  pixel.y = (parameters->param.fy * marker_msg->pose.position.y + parameters->param.cy * marker_msg->pose.position.z) / marker_msg->pose.position.z;
 
   switch(jointType) {
     case 3:


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- Using camera intrinsics (RGB sensor) to publish projected 2D points as PixelSkeleton messages

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Required before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/microsoft/Azure_Kinect_ROS_Driver/blob/master/docs/building.md) locally
- [ ] I tested my changes with a device
- [ ] I changed both the ROS1 and ROS2 branches

<!-- Please test on both Windows and Linux as well as ROS1 and ROS2. Please check off the appropriate boxes with [x]  -->
### I tested changes on: 
- [ ] Windows
- [ ] Linux
- [ ] ROS1
- [ ] ROS2


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

